### PR TITLE
fix(codegen): handle zero param updates

### DIFF
--- a/tests/sqlite/sqlite-code-generator.test.ts
+++ b/tests/sqlite/sqlite-code-generator.test.ts
@@ -1225,4 +1225,24 @@ WHERE max(c1.id, :param3) = min(c2.id, :param3)`;
 		}
 		assert.deepStrictEqual(actual.right, expected);
 	});
+
+	it('update-no-data - UPDATE with no SET parameters should not include data parameter', () => {
+		const sql = 'UPDATE mytable1 SET value = 42 WHERE id = ?';
+
+		const actual = generateTsCode(sql, 'updateNoData', sqliteDbSchema, 'better-sqlite3');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+
+		// The function should only have (db: Database, params: UpdateNoDataParams)
+		// NOT (db: Database, data: UpdateNoDataData, params: UpdateNoDataParams)
+		const expectedFunction = 'function updateNoData(db: Database, params: UpdateNoDataParams): UpdateNoDataResult';
+		assert.ok(actual.right.includes(expectedFunction), 
+			`Expected function signature '${expectedFunction}' not found in generated code:\n${actual.right}`);
+		
+		// Should not include data parameter type since there are no data parameters
+		assert.ok(!actual.right.includes('UpdateNoDataData'), 
+			`Should not include UpdateNoDataData type when there are no data parameters`);
+	});
 });


### PR DESCRIPTION
**The issue**: the type declaration for "data" was generated only when there are parameters to put in there, but the data argument in the function declaration was printed indiscriminately.

For example, the following sql...
```sql
-- incr.sql
UPDATE counter
SET value = value + 1
WHERE key = 'count';
```
...is transformed into this typescript module:
```ts
import type { Database } from 'bun:sqlite';

export type IncrResult = {
	changes: number;
}

export function incr(db: Database, data: IncrData): IncrResult {
	const sql = `
	UPDATE counter
	SET value = value + 1
	WHERE key = 'count';
	
	`
	return db.prepare(sql)
		.run() as IncrResult;
}
```
The `IncrData` type is not defined anywhere.

**Fix**: The [check that guarded the printing of the data type](https://github.com/lilnasy/typesql/blob/d142bbba5fbf8ae26c33c94a5e55ffa659a1e423/src/sqlite-query-analyzer/code-generator.ts#L698-L700) is now also performed before printing the data argument.

Note: the test is AI generated