### PR TITLE
feat(config): add outDir option to config

### DIFF
--- a/src/code-generator.ts
+++ b/src/code-generator.ts
@@ -684,7 +684,7 @@ export function convertToCamelCaseName(name: string): CamelCaseName {
 	return camelCaseStr;
 }
 
-export async function generateTsFile(client: DatabaseClient, sqlFile: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean) {
+export async function generateTsFile(client: DatabaseClient, sqlFile: string, outDir: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean) {
 	const sqlContent = fs.readFileSync(sqlFile, 'utf8');
 
 	if (sqlContent.trim() === '') {
@@ -692,7 +692,7 @@ export async function generateTsFile(client: DatabaseClient, sqlFile: string, sc
 		return;
 	}
 
-	const { name: fileName, dir: dirPath } = parse(sqlFile);
+	const { name: fileName } = parse(sqlFile);
 	const queryName = convertToCamelCaseName(fileName);
 
 	const tsContentResult = await generateTypeScriptContent({
@@ -703,7 +703,7 @@ export async function generateTsFile(client: DatabaseClient, sqlFile: string, sc
 		isCrudFile,
 	})
 
-	const tsFilePath = `${path.resolve(dirPath, fileName)}.ts`;
+	const tsFilePath = `${path.resolve(outDir, fileName)}.ts`;
 	if (isLeft(tsContentResult)) {
 		console.error('ERROR: ', tsContentResult.left.description);
 		console.error('at ', sqlFile);

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,6 +168,7 @@ export type PgDielect = {
 export type TypeSqlConfig = {
 	databaseUri: string;
 	sqlDir: string;
+	outDir?: string;
 	client: TypeSqlDialect;
 	authToken?: string;
 	attach?: string[];


### PR DESCRIPTION
Adds an `outDir` option to the config, which defaults to the value of `sqlDir` if not specified.

Relates to #80