### PR TITLE
feat(options): add option ignoreFiles option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Options:
 | **sqlDir** | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern. | `./src` |
 | **authToken** | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). ||
 | **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables. | `['users', 'permissions', 'tags']` |
+| **ignoreFiles** | Glob pattern(s) for SQL files to ignore. Can be a single pattern or an array of patterns. | <ul><li>`"**/*-draft.sql"`</li><li>`["**/test-*.sql", "**/temp/**"]`</li></ul> |
 
 To load variables from a `.env` file, pass the `--env-file` flag:
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -109,9 +109,11 @@ function validateDirectories(dir: string) {
 
 function watchDirectories(client: DatabaseClient, sqlDir: string, outDir: string, dbSchema: SchemaInfo | PostgresSchemaInfo, config: TypeSqlConfig) {
 	const dirGlob = `${sqlDir}/**/*.sql`;
+	const ignorePatterns = normalizeIgnorePatterns(config.ignoreFiles);
 
 	chokidar
 		.watch(dirGlob, {
+			ignored: ignorePatterns,
 			awaitWriteFinish: {
 				stabilityThreshold: 100
 			}
@@ -152,8 +154,9 @@ async function compile(watch: boolean, config: TypeSqlConfig) {
 
 	await generateCrudTables(outDir, dbSchema.value, includeCrudTables);
 	const dirGlob = `${sqlDir}/**/*.sql`;
+	const ignorePatterns = normalizeIgnorePatterns(config.ignoreFiles);
 
-	const sqlFiles = globSync(dirGlob);
+	const sqlFiles = globSync(dirGlob, { ignore: ignorePatterns });
 
 	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath)));
 	await Promise.all(filesGeneration);
@@ -310,4 +313,11 @@ function isCrudFile(sqlDir: string, sqlFile: string): boolean {
 	const relative = path.relative(`${sqlDir}/${CRUD_FOLDER}`, sqlFile);
 	const result = relative != null && !relative.startsWith('..') && !path.isAbsolute(relative);
 	return result;
+}
+
+function normalizeIgnorePatterns(ignoreFiles: string | string[] | undefined): string[] {
+	if (!ignoreFiles) {
+		return [];
+	}
+	return Array.isArray(ignoreFiles) ? ignoreFiles : [ignoreFiles];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,11 @@ export type TypeSqlConfig = {
 	 * Defaults to ['public'] if not specified.
 	 */
 	schemas?: string[];
+	/**
+	 * Optional glob pattern or list of glob patterns for SQL files to ignore.
+	 * Example: "**\/*-draft.sql" or ["**\/*-draft.sql", "tests/**\/*.sql"]
+	 */
+	ignoreFiles?: string | string[];
 };
 
 export type SqlGenOption = 'select' | 's' | 'insert' | 'i' | 'update' | 'u' | 'delete' | 'd';


### PR DESCRIPTION
Add an option to ignore files using one or multiple globs

<img width="1188" height="599" alt="image" src="https://github.com/user-attachments/assets/38261f8c-da00-47b0-ae7f-244f679b6e44" />


example usage:
```
{
  "databaseUri": "../timesheets-tracker-database.sqlite3",
  "sqlDir": "./src",
  "client": "bun:sqlite",
  "includeCrudTables": [],
  "ignoreFiles": [
    "./src/seed/**",
    "./src/database/queries/create-database-tables.sql"
  ]
}
```

before this change i would get errors about multiple queries in seed sql files:
```
> npx typesql compile

finished!
ERROR:  The supplied SQL string contains more than one statement
at  src\seed\tags.seed.sql
ERROR:  The supplied SQL string contains more than one statement
at  src\seed\auto-tags.seed.sql
ERROR:  The supplied SQL string contains more than one statement
at  src\seed\activities.seed.sql
ERROR:  The supplied SQL string contains more than one statement
at  src\database\queries\create-database-tables.sql

Process finished with exit code 0
```

after adding the ignore files option no more errors:
```
> npx typesql compile

finished!
```