### PR TITLE
fix(parser): correctly handle quotes in mysql and sqlite column names

### DIFF
--- a/src/mysql-query-analyzer/select-columns.ts
+++ b/src/mysql-query-analyzer/select-columns.ts
@@ -88,9 +88,9 @@ export function selectAllColumns(tablePrefix: string, fromColumns: ColumnDef[]) 
 }
 
 export function getColumnName(selectItem: SelectItemContext) {
-	const alias = selectItem.selectAlias()?.identifier()?.getText();
-	if (alias) {
-		return alias;
+	const aliasRaw = selectItem.selectAlias()?.identifier()?.getText();
+	if (aliasRaw) {
+		return aliasRaw.startsWith('"') && aliasRaw.endsWith('"') ? aliasRaw.slice(1, -1) : aliasRaw;
 	}
 	const tokens = getSimpleExpressions(selectItem);
 	const columnName = extractOriginalSql(selectItem.expr()!)!; //TODO VERIFICAR NULL

--- a/src/mysql-query-analyzer/select-columns.ts
+++ b/src/mysql-query-analyzer/select-columns.ts
@@ -87,10 +87,21 @@ export function selectAllColumns(tablePrefix: string, fromColumns: ColumnDef[]) 
 	return allColumns;
 }
 
+const stripQuotes = (text: string) => text.slice(1, -1);
+
 export function getColumnName(selectItem: SelectItemContext) {
-	const aliasRaw = selectItem.selectAlias()?.identifier()?.getText();
-	if (aliasRaw) {
-		return aliasRaw.startsWith('"') && aliasRaw.endsWith('"') ? aliasRaw.slice(1, -1) : aliasRaw;
+	const identifier = selectItem.selectAlias()?.identifier();
+	if (identifier) {
+		const pureIdentifier = identifier.pureIdentifier();
+		if (pureIdentifier?.BACK_TICK_QUOTED_ID() || pureIdentifier?.DOUBLE_QUOTED_TEXT()) {
+			return stripQuotes(pureIdentifier.getText()); //id as `customQuotedName`
+		}
+		return identifier.getText();
+	}
+	const textStringLiteral = selectItem.selectAlias()?.textStringLiteral();
+	//id as "customQuotedName" or id as 'customQuotedName'
+	if (textStringLiteral?.DOUBLE_QUOTED_TEXT() || textStringLiteral?.SINGLE_QUOTED_TEXT()) {
+		return stripQuotes(textStringLiteral.getText());
 	}
 	const tokens = getSimpleExpressions(selectItem);
 	const columnName = extractOriginalSql(selectItem.expr()!)!; //TODO VERIFICAR NULL

--- a/src/sqlite-query-analyzer/traverse.ts
+++ b/src/sqlite-query-analyzer/traverse.ts
@@ -257,7 +257,8 @@ function traverse_select_core(
 		}
 
 		const expr = result_column.expr();
-		const alias = result_column.column_alias()?.getText();
+		const aliasRaw = result_column.column_alias()?.getText();
+		const alias = aliasRaw && aliasRaw.startsWith('"') && aliasRaw.endsWith('"') ? aliasRaw.slice(1, -1) : aliasRaw;
 		if (expr) {
 			const exprType = traverse_expr(expr, {
 				...traverseContext,

--- a/tests/parse-select-single-table.test.ts
+++ b/tests/parse-select-single-table.test.ts
@@ -73,7 +73,7 @@ describe('Test simple select statements', () => {
 	});
 
 	it('SELECT id as "customQuotedName" FROM mytable1 - quoted alias', async () => {
-		const sql = 'SELECT id as "customQuotedName" FROM mytable1';
+		const sql = `SELECT id as "customQuotedName", id as 'customQuotedName2', id as \`customQuotedName3\` FROM mytable1`;
 		const actual = await parseSql(client, sql);
 		const expected: SchemaDef = {
 			sql,
@@ -82,6 +82,18 @@ describe('Test simple select statements', () => {
 			columns: [
 				{
 					name: 'customQuotedName',
+					type: 'int',
+					notNull: true,
+					table: 'mytable1'
+				},
+				{
+					name: 'customQuotedName2',
+					type: 'int',
+					notNull: true,
+					table: 'mytable1'
+				},
+				{
+					name: 'customQuotedName3',
 					type: 'int',
 					notNull: true,
 					table: 'mytable1'

--- a/tests/parse-select-single-table.test.ts
+++ b/tests/parse-select-single-table.test.ts
@@ -72,6 +72,30 @@ describe('Test simple select statements', () => {
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('SELECT id as "customQuotedName" FROM mytable1 - quoted alias', async () => {
+		const sql = 'SELECT id as "customQuotedName" FROM mytable1';
+		const actual = await parseSql(client, sql);
+		const expected: SchemaDef = {
+			sql,
+			queryType: 'Select',
+			multipleRowsResult: true,
+			columns: [
+				{
+					name: 'customQuotedName',
+					type: 'int',
+					notNull: true,
+					table: 'mytable1'
+				}
+			],
+			parameters: []
+		};
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('SELECT * FROM mytable1', async () => {
 		const sql = 'SELECT * FROM mytable1';
 

--- a/tests/sqlite/sqlite-parse-select-single-table.test.ts
+++ b/tests/sqlite/sqlite-parse-select-single-table.test.ts
@@ -93,6 +93,30 @@ describe('sqlite-Test simple select statements', () => {
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('SELECT id as "customQuotedName" FROM mytable1 - quoted alias', async () => {
+		const sql = 'SELECT id as "customQuotedName" FROM mytable1';
+		const actual = await parseSql(sql, sqliteDbSchema);
+		const expected: SchemaDef = {
+			sql,
+			queryType: 'Select',
+			multipleRowsResult: true,
+			columns: [
+				{
+					name: 'customQuotedName',
+					type: 'INTEGER',
+					notNull: true,
+					table: 'mytable1'
+				}
+			],
+			parameters: []
+		};
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('SELECT * FROM mytable1', async () => {
 		const sql = 'SELECT * FROM mytable1';
 


### PR DESCRIPTION
fixed for
* mysql
* sqlite
* postgres (already handled this case correctly)

Added tests as well

Before this change, this valid sql:
```sql
SELECT
    autoTags.id,
    autoTags.title,
    autoTags.tagNameId,
    autoTags.priority,
    autoTags.conditions,
    tagNames.id as "tagName.id",
    tagNames.title as "tagName.title",
    tagNames.color as "tagName.color"
FROM autoTags
LEFT JOIN tagNames ON tagNames.id = autoTags.tagNameId
```

Would produce typescript types that are syntactically incorrect with escaped double quotes:
```typescript
export type FindAllAutoTagsResult = {
	id: string;
	title: string;
	tagNameId: string;
	priority: number;
	conditions: string;
	""tagName.id"": string;
	""tagName.title"": string;
	""tagName.color"": string;
}
```

Now it correctly handles that case:
```typescript
export type FindAllAutoTagsResult = {
	id: string;
	title: string;
	tagNameId: string;
	priority: number;
	conditions: string;
	"tagName.id": string;
	"tagName.title": string;
	"tagName.color": string;
}
```