### PR TITLE
fix(codegen): trim the sql string before processing

### DIFF
--- a/src/codegen/mysql2.ts
+++ b/src/codegen/mysql2.ts
@@ -121,7 +121,7 @@ export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: str
 
 	const escapedBackstick = scapeBackStick(tsDescriptor.sql);
 	const processedSql = replaceOrderByParam(escapedBackstick);
-	const sqlSplit = processedSql.split('\n');
+	const sqlSplit = processedSql.trim().split('\n');
 
 	writer.write(`export async function ${camelCaseName}(${functionArguments}): Promise<${functionReturnType}>`).block(() => {
 		if (tsDescriptor.dynamicQuery == null) {

--- a/src/codegen/pg.ts
+++ b/src/codegen/pg.ts
@@ -535,7 +535,7 @@ function _writeExecFunction(writer: CodeBlockWriter, params: ExecFunctionParamet
 }
 
 function writeSql(writer: CodeBlockWriter, sql: string) {
-	const sqlSplit = sql.trimEnd().split('\n');
+	const sqlSplit = sql.trim().split('\n');
 	writer.write('const sql = `').newLine();
 	sqlSplit.forEach((sqlLine) => {
 		writer.indent().write(sqlLine.trimEnd()).newLine();

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -954,7 +954,7 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 }
 
 function writeSql(writer: CodeBlockWriter, sql: string) {
-	const sqlSplit = sql.split('\n');
+	const sqlSplit = sql.trim().split('\n');
 	writer.write('const sql = `').newLine();
 	sqlSplit.forEach((sqlLine) => {
 		writer.indent().write(sqlLine.trimEnd()).newLine();


### PR DESCRIPTION
to avoid trailing whitespace

example:
```sql
SELECT count(*) as count
FROM autoTags
                                    <<<< empty trailing line
```

would be included in the ts file with a trailing newline:
```typescript
export function countAutoTags(db: Database): CountAutoTagsResult | null {
  const sql = `
	SELECT count(*) as count
	FROM autoTags
	
	`;
```

This PR trims that sql before it gets analysed:
```typescript
export function countAutoTags(db: Database): CountAutoTagsResult | null {
	const sql = `
	SELECT count(*) as count
	FROM autoTags
	`
```