### PR TITLE
feat: add option to disable index.ts files generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ npm install -g typesql-cli
 
 Options:
 
-| Option | Description                                                                                                      | Example                                                                                                 |
-| :--- |:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
-| **client** | Database client driver to use.                                                                                   | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
-| **databaseUri** | Connection string for the database. Supports environment variables (`${VAR_NAME}`).                              | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul>                        |
-| **sqlDir** | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern.        | `./src`                                                                                                 |
-| **authToken** | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). |                                                                                                         |
-| **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables.                               | `['users', 'permissions', 'tags']`                                                                      |
+| Option                 | Description                                                                                                      | Example                                                                                                 |
+| :--------------------- | :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------------------------ |
+| **client**             | Database client driver to use.                                                                                   | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
+| **databaseUri**        | Connection string for the database. Supports environment variables (`${VAR_NAME}`).                              | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul>                        |
+| **sqlDir**             | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern.        | `./src`                                                                                                 |
+| **authToken**          | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). |                                                                                                         |
+| **includeCrudTables**  | Generates `select`, `insert`, `update`, and `delete` queries for specified tables.                               | `['users', 'permissions', 'tags']`                                                                      |
 | **generateIndexFiles** | Whether to recursively generate index.ts barrel files in each output folder. Defaults to true if not specified.  | true                                                                                                    |
 
 To load variables from a `.env` file, pass the `--env-file` flag:

--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ npm install -g typesql-cli
 
 Options:
 
-| Option | Description | Example |
-| :--- | :--- | :--- |
-| **client** | Database client driver to use. | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
-| **databaseUri** | Connection string for the database. Supports environment variables (`${VAR_NAME}`). | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul> |
-| **sqlDir** | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern. | `./src` |
-| **authToken** | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). ||
-| **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables. | `['users', 'permissions', 'tags']` |
+| Option | Description                                                                                                      | Example                                                                                                 |
+| :--- |:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
+| **client** | Database client driver to use.                                                                                   | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
+| **databaseUri** | Connection string for the database. Supports environment variables (`${VAR_NAME}`).                              | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul>                        |
+| **sqlDir** | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern.        | `./src`                                                                                                 |
+| **authToken** | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). |                                                                                                         |
+| **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables.                               | `['users', 'permissions', 'tags']`                                                                      |
+| **generateIndexFiles** | Whether to recursively generate index.ts barrel files in each output folder. Defaults to true if not specified.  | true                                                                                                    |
 
 To load variables from a `.env` file, pass the `--env-file` flag:
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -124,7 +124,9 @@ async function rewiteFiles(client: DatabaseClient, sqlPath: string, sqlDir: stri
 	const tsFilePath = resolveTsFilePath(sqlPath, sqlDir, outDir);
 	await generateTsFile(client, sqlPath, tsFilePath, schemaInfo, isCrudFile);
 	const tsDir = path.dirname(tsFilePath);
-	writeIndexFileFor(tsDir, config);
+	if (config.generateIndexFiles !== false) {
+		writeIndexFileFor(tsDir, config);
+	}
 }
 
 async function main() {
@@ -158,7 +160,9 @@ async function compile(watch: boolean, config: TypeSqlConfig) {
 	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath)));
 	await Promise.all(filesGeneration);
 
-	writeIndexFile(outDir, config);
+	if (config.generateIndexFiles !== false) {
+		writeIndexFile(outDir, config);
+	}
 
 	if (watch) {
 		console.log('watching mode!');

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,11 @@ export type TypeSqlConfig = {
 	 * Defaults to ['public'] if not specified.
 	 */
 	schemas?: string[];
+	/**
+	 * Whether to recursively generate index.ts barrel files in each output folder.
+	 * Defaults to true if not specified.
+	 */
+	generateIndexFiles?: boolean;
 };
 
 export type SqlGenOption = 'select' | 's' | 'insert' | 'i' | 'update' | 'u' | 'delete' | 'd';


### PR DESCRIPTION
Since some developers use their src folder as the root dir
It generates index.ts files even for folders that have no sql files

I left the default on true, so current behavior is maintained.
But personally i would disable this by default.

<img width="944" height="396" alt="image" src="https://github.com/user-attachments/assets/de26c248-4521-462a-a372-64ea059ccf72" />

