### PR TITLE
feat(codegen): add option to force line endings to \n or \n\r

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Options:
 | **sqlDir**            | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern.             | `./src`                                                                                                 |
 | **authToken**         | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`).      |                                                                                                         |
 | **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables.                                    | `['users', 'permissions', 'tags']`                                                                      |
-| **lineEndings**       | Defines the line-endings to use in the generated files. If this option is omitted, it will default to the OS default. | <ul><li>`\n\r`</li><li>`\n`</li>                                                                        |
+| **endOfLine**         | End-of-line style to use in generated files. If this option is omitted, it will default to the OS default.           | <ul><li>`CRLF`</li><li>`LF`</li></ul>                                                                  |                                                                        |
 
 To load variables from a `.env` file, pass the `--env-file` flag:
 ```sh

--- a/README.md
+++ b/README.md
@@ -79,13 +79,14 @@ npm install -g typesql-cli
 
 Options:
 
-| Option | Description | Example |
-| :--- | :--- | :--- |
-| **client** | Database client driver to use. | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
-| **databaseUri** | Connection string for the database. Supports environment variables (`${VAR_NAME}`). | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul> |
-| **sqlDir** | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern. | `./src` |
-| **authToken** | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`). ||
-| **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables. | `['users', 'permissions', 'tags']` |
+| Option                | Description                                                                                                           | Example                                                                                                 |
+|:----------------------|:----------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
+| **client**            | Database client driver to use.                                                                                        | <ul><li>pg</li><li>mysql2</li><li>better-sqlite3</li><li>libsql</li><li>bun:sqlite</li><li>d1</li></ul> |
+| **databaseUri**       | Connection string for the database. Supports environment variables (`${VAR_NAME}`).                                   | <ul><li>mysql://root:password@localhost/mydb</li><li>./database.sqlite</li></ul>                        |
+| **sqlDir**            | Directory where SQL queries are stored. Will search recursively by appending the `**/*.sql` glob pattern.             | `./src`                                                                                                 |
+| **authToken**         | Authentication token. Required **only for the `libsql` client**. Supports environment variables (`${VAR_NAME}`).      |                                                                                                         |
+| **includeCrudTables** | Generates `select`, `insert`, `update`, and `delete` queries for specified tables.                                    | `['users', 'permissions', 'tags']`                                                                      |
+| **lineEndings**       | Defines the line-endings to use in the generated files. If this option is omitted, it will default to the OS default. | <ul><li>`\n\r`</li><li>`\n`</li>                                                                        |
 
 To load variables from a `.env` file, pass the `--env-file` flag:
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -122,7 +122,7 @@ function watchDirectories(client: DatabaseClient, sqlDir: string, outDir: string
 
 async function rewiteFiles(client: DatabaseClient, sqlPath: string, sqlDir: string, outDir: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean, config: TypeSqlConfig) {
 	const tsFilePath = resolveTsFilePath(sqlPath, sqlDir, outDir);
-	await generateTsFile(client, sqlPath, tsFilePath, schemaInfo, isCrudFile);
+	await generateTsFile(client, sqlPath, tsFilePath, schemaInfo, isCrudFile, config.lineEndings);
 	const tsDir = path.dirname(tsFilePath);
 	writeIndexFileFor(tsDir, config);
 }
@@ -150,12 +150,12 @@ async function compile(watch: boolean, config: TypeSqlConfig) {
 		return;
 	}
 
-	await generateCrudTables(outDir, dbSchema.value, includeCrudTables);
+	await generateCrudTables(outDir, dbSchema.value, includeCrudTables, config.lineEndings);
 	const dirGlob = `${sqlDir}/**/*.sql`;
 
 	const sqlFiles = globSync(dirGlob);
 
-	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath)));
+	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath), config.lineEndings));
 	await Promise.all(filesGeneration);
 
 	writeIndexFile(outDir, config);
@@ -264,7 +264,7 @@ function _filterTables(schemaInfo: SchemaInfo | PostgresSchemaInfo, includeCrudT
 	return filteredTables;
 }
 
-async function generateCrudTables(sqlFolderPath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, includeCrudTables: string[]) {
+async function generateCrudTables(sqlFolderPath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, includeCrudTables: string[], newLine?: '\n' | '\r\n') {
 
 	const filteredTables = _filterTables(schemaInfo, includeCrudTables);
 	for (const tableInfo of filteredTables) {
@@ -277,17 +277,17 @@ async function generateCrudTables(sqlFolderPath: string, schemaInfo: SchemaInfo 
 			checkAndGenerateSql(schemaInfo.kind, `${filePath}update-${tableName}.sql`, 'update', tableName, columns);
 			checkAndGenerateSql(schemaInfo.kind, `${filePath}delete-from-${tableName}.sql`, 'delete', tableName, columns);
 		} else {
-			generateAndWriteCrud(schemaInfo.kind, `${filePath}select-from-${tableName}.ts`, 'Select', tableName, schemaInfo.columns);
-			generateAndWriteCrud(schemaInfo.kind, `${filePath}insert-into-${tableName}.ts`, 'Insert', tableName, schemaInfo.columns);
-			generateAndWriteCrud(schemaInfo.kind, `${filePath}update-${tableName}.ts`, 'Update', tableName, schemaInfo.columns);
-			generateAndWriteCrud(schemaInfo.kind, `${filePath}delete-from-${tableName}.ts`, 'Delete', tableName, schemaInfo.columns);
+			generateAndWriteCrud(schemaInfo.kind, `${filePath}select-from-${tableName}.ts`, 'Select', tableName, schemaInfo.columns, newLine);
+			generateAndWriteCrud(schemaInfo.kind, `${filePath}insert-into-${tableName}.ts`, 'Insert', tableName, schemaInfo.columns, newLine);
+			generateAndWriteCrud(schemaInfo.kind, `${filePath}update-${tableName}.ts`, 'Update', tableName, schemaInfo.columns, newLine);
+			generateAndWriteCrud(schemaInfo.kind, `${filePath}delete-from-${tableName}.ts`, 'Delete', tableName, schemaInfo.columns, newLine);
 		}
 	}
 }
 
-function generateAndWriteCrud(client: 'pg' | SQLiteClient, filePath: string, queryType: CrudQueryType, tableName: string, columns: ColumnSchema[] | PostgresColumnSchema[]) {
+function generateAndWriteCrud(client: 'pg' | SQLiteClient, filePath: string, queryType: CrudQueryType, tableName: string, columns: ColumnSchema[] | PostgresColumnSchema[], newLine?: '\n' | '\r\n') {
 
-	const content = client === 'pg' ? generatePgCrud(queryType, tableName, columns as PostgresColumnSchema[]) : generateCrud(client, queryType, tableName, columns as ColumnSchema[]);
+	const content = client === 'pg' ? generatePgCrud(queryType, tableName, columns as PostgresColumnSchema[], newLine) : generateCrud(client, queryType, tableName, columns as ColumnSchema[], newLine);
 	writeFile(filePath, content);
 	console.log('Generated file:', filePath);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -120,9 +120,15 @@ function watchDirectories(client: DatabaseClient, sqlDir: string, outDir: string
 		.on('change', (path) => rewiteFiles(client, path, sqlDir, outDir, dbSchema, isCrudFile(sqlDir, path), config));
 }
 
+function toNewLine(endOfLine?: 'LF' | 'CRLF'): '\n' | '\r\n' | undefined {
+	if (endOfLine === 'LF') return '\n';
+	if (endOfLine === 'CRLF') return '\r\n';
+	return undefined;
+}
+
 async function rewiteFiles(client: DatabaseClient, sqlPath: string, sqlDir: string, outDir: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean, config: TypeSqlConfig) {
 	const tsFilePath = resolveTsFilePath(sqlPath, sqlDir, outDir);
-	await generateTsFile(client, sqlPath, tsFilePath, schemaInfo, isCrudFile, config.lineEndings);
+	await generateTsFile(client, sqlPath, tsFilePath, schemaInfo, isCrudFile, toNewLine(config.endOfLine));
 	const tsDir = path.dirname(tsFilePath);
 	writeIndexFileFor(tsDir, config);
 }
@@ -150,12 +156,13 @@ async function compile(watch: boolean, config: TypeSqlConfig) {
 		return;
 	}
 
-	await generateCrudTables(outDir, dbSchema.value, includeCrudTables, config.lineEndings);
+	const newLine = toNewLine(config.endOfLine);
+	await generateCrudTables(outDir, dbSchema.value, includeCrudTables, newLine);
 	const dirGlob = `${sqlDir}/**/*.sql`;
 
 	const sqlFiles = globSync(dirGlob);
 
-	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath), config.lineEndings));
+	const filesGeneration = sqlFiles.map((sqlPath) => generateTsFile(databaseClient, sqlPath, resolveTsFilePath(sqlPath, sqlDir, outDir), dbSchema.value, isCrudFile(sqlDir, sqlPath), newLine));
 	await Promise.all(filesGeneration);
 
 	writeIndexFile(outDir, config);

--- a/src/codegen/code-generator.ts
+++ b/src/codegen/code-generator.ts
@@ -9,7 +9,7 @@ import { generateCode } from './pg';
 import { ColumnSchema } from '../mysql-query-analyzer/types';
 import { convertToCamelCaseName } from './shared/codegen-util';
 
-export async function generateTsFile(client: DatabaseClient, sqlFile: string, tsFilePath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean) {
+export async function generateTsFile(client: DatabaseClient, sqlFile: string, tsFilePath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean, lineEndings?: '\n' | '\r\n') {
 	const sqlContent = fs.readFileSync(sqlFile, 'utf8');
 
 	if (sqlContent.trim() === '') {
@@ -26,6 +26,7 @@ export async function generateTsFile(client: DatabaseClient, sqlFile: string, ts
 		sqlContent,
 		schemaInfo,
 		isCrudFile,
+		lineEndings,
 	})
 
 	if (isLeft(tsContentResult)) {
@@ -45,19 +46,20 @@ export async function generateTypeScriptContent(params: {
 	sqlContent: string;
 	schemaInfo: SchemaInfo | PostgresSchemaInfo;
 	isCrudFile: boolean;
+	lineEndings?: '\n' | '\r\n';
 }): Promise<Either<TypeSqlError, string>> {
-	const { client, queryName, sqlContent, schemaInfo, isCrudFile } = params;
+	const { client, queryName, sqlContent, schemaInfo, isCrudFile, lineEndings } = params;
 
 	switch (client.type) {
 		case 'mysql2':
-			return generateTsFileFromContent(client, queryName, sqlContent, isCrudFile);
+			return generateTsFileFromContent(client, queryName, sqlContent, isCrudFile, lineEndings);
 		case 'better-sqlite3':
 		case 'bun:sqlite':
 		case 'libsql':
 		case 'd1':
-			return validateAndGenerateCode(client, sqlContent, queryName, schemaInfo.columns as ColumnSchema[], isCrudFile);
+			return validateAndGenerateCode(client, sqlContent, queryName, schemaInfo.columns as ColumnSchema[], isCrudFile, lineEndings);
 		case 'pg': {
-			const result = await generateCode(client, sqlContent, queryName, schemaInfo as PostgresSchemaInfo);
+			const result = await generateCode(client, sqlContent, queryName, schemaInfo as PostgresSchemaInfo, lineEndings);
 			return result.isErr() ? left(result.error) : right(result.value);
 		}
 	}

--- a/src/codegen/code-generator.ts
+++ b/src/codegen/code-generator.ts
@@ -9,7 +9,7 @@ import { generateCode } from './pg';
 import { ColumnSchema } from '../mysql-query-analyzer/types';
 import { convertToCamelCaseName } from './shared/codegen-util';
 
-export async function generateTsFile(client: DatabaseClient, sqlFile: string, tsFilePath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean, lineEndings?: '\n' | '\r\n') {
+export async function generateTsFile(client: DatabaseClient, sqlFile: string, tsFilePath: string, schemaInfo: SchemaInfo | PostgresSchemaInfo, isCrudFile: boolean, newLine?: '\n' | '\r\n') {
 	const sqlContent = fs.readFileSync(sqlFile, 'utf8');
 
 	if (sqlContent.trim() === '') {
@@ -26,7 +26,7 @@ export async function generateTsFile(client: DatabaseClient, sqlFile: string, ts
 		sqlContent,
 		schemaInfo,
 		isCrudFile,
-		lineEndings,
+		newLine,
 	})
 
 	if (isLeft(tsContentResult)) {
@@ -46,20 +46,20 @@ export async function generateTypeScriptContent(params: {
 	sqlContent: string;
 	schemaInfo: SchemaInfo | PostgresSchemaInfo;
 	isCrudFile: boolean;
-	lineEndings?: '\n' | '\r\n';
+	newLine?: '\n' | '\r\n';
 }): Promise<Either<TypeSqlError, string>> {
-	const { client, queryName, sqlContent, schemaInfo, isCrudFile, lineEndings } = params;
+	const { client, queryName, sqlContent, schemaInfo, isCrudFile, newLine } = params;
 
 	switch (client.type) {
 		case 'mysql2':
-			return generateTsFileFromContent(client, queryName, sqlContent, isCrudFile, lineEndings);
+			return generateTsFileFromContent(client, queryName, sqlContent, isCrudFile, newLine);
 		case 'better-sqlite3':
 		case 'bun:sqlite':
 		case 'libsql':
 		case 'd1':
-			return validateAndGenerateCode(client, sqlContent, queryName, schemaInfo.columns as ColumnSchema[], isCrudFile, lineEndings);
+			return validateAndGenerateCode(client, sqlContent, queryName, schemaInfo.columns as ColumnSchema[], isCrudFile, newLine);
 		case 'pg': {
-			const result = await generateCode(client, sqlContent, queryName, schemaInfo as PostgresSchemaInfo, lineEndings);
+			const result = await generateCode(client, sqlContent, queryName, schemaInfo as PostgresSchemaInfo, newLine);
 			return result.isErr() ? left(result.error) : right(result.value);
 		}
 	}

--- a/src/codegen/mysql2.ts
+++ b/src/codegen/mysql2.ts
@@ -9,8 +9,11 @@ import type { FragmentInfoResult } from '../mysql-query-analyzer/types';
 import { EOL } from 'node:os';
 import { capitalize, convertToCamelCaseName, generateRelationType, ParamInfo, renameInvalidNames, TsDescriptor } from './shared/codegen-util';
 
-export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: string, crud = false): string {
-	const writer = new CodeBlockWriter();
+export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: string, crud = false, newLine?: '\n' | '\r\n'): string {
+	const writer = new CodeBlockWriter({
+		useTabs: true,
+		newLine: newLine ?? EOL as '\n' | '\r\n'
+	});
 
 	const camelCaseName = convertToCamelCaseName(fileName);
 	const capitalizedName = capitalize(camelCaseName);
@@ -619,7 +622,8 @@ export async function generateTsFileFromContent(
 	client: MySqlDialect,
 	queryName: string,
 	sqlContent: string,
-	crud = false
+	crud = false,
+	newLine?: '\n' | '\r\n'
 ): Promise<Either<TypeSqlError, string>> {
 	const queryInfoResult = await parseSql(client, sqlContent);
 
@@ -627,7 +631,7 @@ export async function generateTsFileFromContent(
 		return queryInfoResult;
 	}
 	const tsDescriptor = generateTsDescriptor(queryInfoResult.right);
-	const tsContent = generateTsCodeForMySQL(tsDescriptor, queryName, crud);
+	const tsContent = generateTsCodeForMySQL(tsDescriptor, queryName, crud, newLine);
 	return right(tsContent);
 }
 

--- a/src/codegen/pg.ts
+++ b/src/codegen/pg.ts
@@ -13,12 +13,12 @@ import { PostgresColumnSchema } from '../drivers/types';
 import { writeBuildOrderByBlock, writeBuildSqlFunction, writeDynamicQueryOperators, writeMapToResultFunction, writeOrderByToObjectFunction, writeWhereConditionFunction } from './shared/codegen-util';
 import { Field2 } from '../sqlite-query-analyzer/sqlite-describe-nested-query';
 
-export function generateCode(client: PgDielect, sql: string, queryName: string, schemaInfo: PostgresSchemaInfo): ResultAsync<string, TypeSqlError> {
+export function generateCode(client: PgDielect, sql: string, queryName: string, schemaInfo: PostgresSchemaInfo, newLine?: '\n' | '\r\n'): ResultAsync<string, TypeSqlError> {
 	if (isEmptySql(sql)) {
 		return okAsync('');
 	}
 	return _describeQuery(client, sql, schemaInfo)
-		.map(schemaDef => generateTsCode(queryName, schemaDef, client.type))
+		.map(schemaDef => generateTsCode(queryName, schemaDef, client.type, newLine))
 }
 
 function isEmptySql(sql: string) {
@@ -33,11 +33,11 @@ function _describeQuery(databaseClient: PgDielect, sql: string, dbSchema: Postgr
 	return describeQuery(databaseClient.client, sql, dbSchema);
 }
 
-function generateTsCode(queryName: string, schemaDef: PostgresSchemaDef, client: 'pg'): string {
+function generateTsCode(queryName: string, schemaDef: PostgresSchemaDef, client: 'pg', newLine?: '\n' | '\r\n'): string {
 
 	const { sql } = schemaDef;
 
-	const writer = createCodeBlockWriter();
+	const writer = createCodeBlockWriter(newLine);
 
 	const {
 		camelCaseName,
@@ -586,7 +586,7 @@ function isList(param: TsParameterDescriptor) {
 	return param.tsType.endsWith('[]') && !param.isArray;
 }
 
-export function generateCrud(queryType: CrudQueryType, tableName: string, dbSchema: PostgresColumnSchema[]) {
+export function generateCrud(queryType: CrudQueryType, tableName: string, dbSchema: PostgresColumnSchema[], newLine?: '\n' | '\r\n') {
 
 	const queryName = getQueryName(queryType, tableName);
 	const camelCaseName = convertToCamelCaseName(queryName);
@@ -595,8 +595,7 @@ export function generateCrud(queryType: CrudQueryType, tableName: string, dbSche
 	const resultTypeName = `${capitalizedName}Result`;
 	const paramsTypeName = `${capitalizedName}Params`;
 
-	const writer = createCodeBlockWriter();
-
+	const writer = createCodeBlockWriter(newLine);
 	const allColumns = dbSchema.filter((col) => col.table === tableName);
 	const keyColumns = allColumns.filter((col) => col.column_key === 'PRI');
 	if (keyColumns.length === 0) {

--- a/src/codegen/shared/codegen-util.ts
+++ b/src/codegen/shared/codegen-util.ts
@@ -38,10 +38,10 @@ export type TypeNames = {
 	whereTypeName: string;
 }
 
-export function createCodeBlockWriter() {
+export function createCodeBlockWriter(newLine?: '\n' | '\r\n') {
 	const writer = new CodeBlockWriter({
 		useTabs: true,
-		newLine: EOL as '\n' | '\r\n'
+		newLine: newLine ?? EOL as '\n' | '\r\n'
 	});
 	return writer;
 }

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -52,7 +52,8 @@ export function validateAndGenerateCode(
 	sql: string,
 	queryName: string,
 	sqliteDbSchema: ColumnSchema[],
-	isCrud = false
+	isCrud = false,
+	newLine?: '\n' | '\r\n'
 ): Either<TypeSqlError, string> {
 	const { sql: processedSql } = preprocessSql(sql, 'sqlite');
 	const explainSqlResult = explainSql(client.client, processedSql);
@@ -62,7 +63,7 @@ export function validateAndGenerateCode(
 			description: explainSqlResult.left.description
 		});
 	}
-	const code = generateTsCode(sql, queryName, sqliteDbSchema, client.type, isCrud);
+	const code = generateTsCode(sql, queryName, sqliteDbSchema, client.type, isCrud, newLine);
 	return code;
 }
 
@@ -78,7 +79,7 @@ function mapToColumnInfo(col: ColumnSchema, checkOptional: boolean) {
 	return columnInfo;
 }
 
-export function generateCrud(client: SQLiteClient, queryType: CrudQueryType, tableName: string, dbSchema: ColumnSchema[]) {
+export function generateCrud(client: SQLiteClient, queryType: CrudQueryType, tableName: string, dbSchema: ColumnSchema[], newLine?: '\n' | '\r\n') {
 	const columns = dbSchema.filter((col) => col.table === tableName);
 
 	const columnInfo = columns.map((col) => mapToColumnInfo(col, queryType === 'Insert' || queryType === 'Update'));
@@ -103,7 +104,7 @@ export function generateCrud(client: SQLiteClient, queryType: CrudQueryType, tab
 
 	const queryName = getQueryName(queryType, tableName);
 
-	const code = generateCodeFromTsDescriptor(client, queryName, tsDescriptor, true, tableName);
+	const code = generateCodeFromTsDescriptor(client, queryName, tsDescriptor, true, tableName, newLine);
 	return code;
 }
 
@@ -127,14 +128,15 @@ export function generateTsCode(
 	queryName: string,
 	sqliteDbSchema: ColumnSchema[],
 	client: SQLiteClient,
-	isCrud = false
+	isCrud = false,
+	newLine?: '\n' | '\r\n'
 ): Either<TypeSqlError, string> {
 	const schemaDefResult = parseSql(sql, sqliteDbSchema);
 	if (isLeft(schemaDefResult)) {
 		return schemaDefResult;
 	}
 	const tsDescriptor = createTsDescriptor(schemaDefResult.right, client);
-	const code = generateCodeFromTsDescriptor(client, queryName, tsDescriptor, isCrud);
+	const code = generateCodeFromTsDescriptor(client, queryName, tsDescriptor, isCrud, undefined, newLine);
 	return right(code);
 }
 
@@ -296,8 +298,8 @@ function mapColumnToTsParameterDescriptor(col: ColumnInfo, client: SQLiteClient)
 	return tsDesc;
 }
 
-function generateCodeFromTsDescriptor(client: SQLiteClient, queryName: string, tsDescriptor: TsDescriptor, isCrud = false, tableName = '') {
-	const writer = createCodeBlockWriter();
+function generateCodeFromTsDescriptor(client: SQLiteClient, queryName: string, tsDescriptor: TsDescriptor, isCrud = false, tableName = '', newLine?: '\n' | '\r\n') {
+	const writer = createCodeBlockWriter(newLine);
 
 	const {
 		camelCaseName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,10 +183,10 @@ export type TypeSqlConfig = {
 	 */
 	schemas?: string[];
 	/**
-	 * Line ending style to use in generated files.
+	 * End-of-line style to use in generated files.
 	 * Defaults to the OS line ending if not specified.
 	 */
-	lineEndings?: '\n' | '\r\n';
+	endOfLine?: 'LF' | 'CRLF';
 };
 
 export type SqlGenOption = 'select' | 's' | 'insert' | 'i' | 'update' | 'u' | 'delete' | 'd';

--- a/src/types.ts
+++ b/src/types.ts
@@ -182,6 +182,11 @@ export type TypeSqlConfig = {
 	 * Defaults to ['public'] if not specified.
 	 */
 	schemas?: string[];
+	/**
+	 * Line ending style to use in generated files.
+	 * Defaults to the OS line ending if not specified.
+	 */
+	lineEndings?: '\n' | '\r\n';
 };
 
 export type SqlGenOption = 'select' | 's' | 'insert' | 'i' | 'update' | 'u' | 'delete' | 'd';


### PR DESCRIPTION
Not everyone uses their system default line-endings.
For instance in recent years, more and more windows developers are adapting the mac/linux standard of using \n line endings. But typesql always uses the OS default. Which causes files to be generated with the wrong line endings.

| Option                | Description                                                                                                           | Example                                                                                                 |
|:----------------------|:----------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------------------|
| **endOfLine**         | End-of-line style to use in generated files. If this option is omitted, it will default to the OS default.           | <ul><li>`CRLF`</li><li>`LF`</li></ul>                                                                  |                                                                        |

