### PR TITLE
fix(sqlite): UPSERT reused-named-param arg miscount

### DIFF
--- a/src/sqlite-query-analyzer/traverse.ts
+++ b/src/sqlite-query-analyzer/traverse.ts
@@ -2031,8 +2031,8 @@ function traverse_insert_stmt(insert_stmt: Insert_stmtContext, traverseContext: 
 	const upsert_clause = insert_stmt.upsert_clause();
 	if (upsert_clause) {
 		const assign_list = upsert_clause.ASSIGN_list();
-		const paramsBefore = traverseContext.parameters.length;
 		assign_list.forEach((_, index) => {
+			const paramsBefore = traverseContext.parameters.length;
 			const column_name = upsert_clause.column_name(index);
 			const col = traverse_column_name(column_name, null, fromColumns);
 			const expr = upsert_clause.expr(index);

--- a/tests/sqlite/parse-insert.test.ts
+++ b/tests/sqlite/parse-insert.test.ts
@@ -482,6 +482,60 @@ describe('sqlite-parse-insert', () => {
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('UPSERT with :ts reused across VALUES and DO UPDATE (issue #118 repro)', () => {
+		const sql = `
+        INSERT INTO mytable2 (id, name, descr)
+        VALUES (:id, :name, :descr)
+        ON CONFLICT(id) DO UPDATE SET name = COALESCE(:name, name), descr = :descr`;
+		const actual = parseSql(sql, sqliteDbSchema);
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		// 5 `?` placeholders: :id, :name, :descr in VALUES + :name, :descr in upsert.
+		// Before fix: parameters length was 6 with a synthetic `param6` at index 5.
+		assert.strictEqual(actual.right.parameters.length, 5);
+		const names = actual.right.parameters.map((p) => p.name);
+		assert.deepStrictEqual(names, ['id', 'name', 'descr', 'name', 'descr']);
+		for (const p of actual.right.parameters) {
+			assert.ok(!/^param\d+$/.test(p.name), `synthetic param leaked: ${p.name}`);
+		}
+	});
+
+	it('UPSERT with two reused named params (direct assign)', () => {
+		const sql = `
+        INSERT INTO mytable2 (id, name, descr)
+        VALUES (:id, :name, :descr)
+        ON CONFLICT(id) DO UPDATE SET name = :name, descr = :descr`;
+		const actual = parseSql(sql, sqliteDbSchema);
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.strictEqual(actual.right.parameters.length, 5);
+		assert.deepStrictEqual(
+			actual.right.parameters.map((p) => p.name),
+			['id', 'name', 'descr', 'name', 'descr']
+		);
+	});
+
+	it('UPSERT with fresh named params not in VALUES', () => {
+		const sql = `
+        INSERT INTO mytable2 (id, name, descr)
+        VALUES (:id, :name, :descr)
+        ON CONFLICT(id) DO UPDATE SET name = :newname, descr = :newdescr`;
+		const actual = parseSql(sql, sqliteDbSchema);
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.strictEqual(actual.right.parameters.length, 5);
+		assert.deepStrictEqual(
+			actual.right.parameters.map((p) => p.name),
+			['id', 'name', 'descr', 'newname', 'newdescr']
+		);
+		for (const p of actual.right.parameters) {
+			assert.ok(!/^param\d+$/.test(p.name), `synthetic param leaked: ${p.name}`);
+		}
+	});
+
 	it('INSERT INTO mytable2 (id, name) SELECT ?, ?', async () => {
 		const sql = `
         INSERT INTO mytable2 (id, name)


### PR DESCRIPTION
When a named param appears in both `VALUES` and an `ON CONFLICT DO UPDATE SET` clause with multiple assignments, the positional args array ended up one entry too long and a synthetic `paramN` field leaked onto the generated Params type.

Root cause: in traverse.ts, the upsert loop captured `paramsBefore = traverseContext.parameters.length` once before the forEach over assignments. Each iteration's `slice(paramsBefore)` then re-included params added by earlier iterations, double-pushing them into insertColumns. Moving the capture inside the forEach fixes it.

Adds three parse-insert tests covering:
- the issue's COALESCE + reuse repro
- two reused named params with direct assigns
- fresh named params in the upsert clause

Fixes #118.