### PR TITLE
fix(codegen): use `| null` in sqlite and mysql

### DIFF
--- a/src/codegen/mysql2.ts
+++ b/src/codegen/mysql2.ts
@@ -4,9 +4,9 @@ import { mapper, type MySqlType } from '../mysql-mapping';
 import { parseSql } from '../describe-query';
 import CodeBlockWriter from 'code-block-writer';
 import { createNestedTsDescriptor } from '../ts-nested-descriptor';
-import { mapToDynamicResultColumns, mapToDynamicParams, mapToDynamicSelectColumns } from '../ts-dynamic-query-descriptor';
+import { mapToDynamicParams, mapToDynamicSelectColumns } from '../ts-dynamic-query-descriptor';
 import type { FragmentInfoResult } from '../mysql-query-analyzer/types';
-import { capitalize, convertToCamelCaseName, generateRelationType, ParamInfo, renameInvalidNames, TsDescriptor, writeSql } from './shared/codegen-util';
+import { capitalize, convertToCamelCaseName, generateRelationType, ParamInfo, renameInvalidNames, TsDescriptor, writeResultType, writeSql } from './shared/codegen-util';
 
 export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: string, crud = false): string {
 	const writer = new CodeBlockWriter();
@@ -53,8 +53,11 @@ export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: str
 	}
 
 	writeTypeBlock(writer, paramsTypes, paramsTypeName, false, tsDescriptor.dynamicQuery ? undefined : orderByField);
-	const resultTypes = tsDescriptor.dynamicQuery == null ? tsDescriptor.columns : mapToDynamicResultColumns(tsDescriptor.columns);
-	writeTypeBlock(writer, resultTypes, resultTypeName, false);
+	const resultTypes = tsDescriptor.dynamicQuery == null
+		? tsDescriptor.columns
+		: tsDescriptor.columns.map((c) => ({ ...c, optional: true, notNull: true }));
+	writeResultType(writer, resultTypeName, resultTypes);
+	writer.blankLine();
 	if (tsDescriptor.dynamicQuery) {
 		const selectFields = mapToDynamicSelectColumns(tsDescriptor.columns);
 		writeTypeBlock(writer, selectFields, selectColumnsTypeName, false);
@@ -343,8 +346,8 @@ export function generateTsCodeForMySQL(tsDescriptor: TsDescriptor, fileName: str
 					}
 					if (field.type === 'relation') {
 						const nestedRelationType = generateRelationType(capitalizedName, field.tsType);
-						const nullableOperator = field.notNull ? '' : '?';
-						writer.writeLine(`${field.name}${nullableOperator}: ${nestedRelationType};`);
+						const nullable = field.notNull ? '' : ' | null';
+						writer.writeLine(`${field.name}: ${nestedRelationType}${nullable};`);
 					}
 				});
 			});

--- a/src/codegen/shared/codegen-util.ts
+++ b/src/codegen/shared/codegen-util.ts
@@ -473,6 +473,16 @@ export function writeOrderByToObjectFunction(writer: CodeBlockWriter, dynamicPar
 	});
 }
 
+export function writeResultType(writer: CodeBlockWriter, resultTypeName: string, columns: TsFieldDescriptor[]) {
+	writer.write(`export type ${resultTypeName} =`).block(() => {
+		columns.forEach((field) => {
+			const optionalOp = field.optional ? '?' : '';
+			const nullable = field.notNull ? '' : ' | null';
+			writer.writeLine(`${field.name}${optionalOp}: ${field.tsType}${nullable};`);
+		});
+	});
+}
+
 export function writeNestedTypes(writer: CodeBlockWriter, relations: RelationType2[], captalizedName: string) {
 	relations.forEach((relation) => {
 		const relationType = generateRelationType(captalizedName, relation.name);

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -22,9 +22,9 @@ import type { Field2 } from '../sqlite-query-analyzer/sqlite-describe-nested-que
 import { type RelationType2, type TsField2, mapToTsRelation2 } from '../ts-nested-descriptor';
 import { preprocessSql } from '../describe-query';
 import { explainSql } from '../sqlite-query-analyzer/query-executor';
-import { mapToDynamicParams, mapToDynamicResultColumns, mapToDynamicSelectColumns } from '../ts-dynamic-query-descriptor';
+import { mapToDynamicParams, mapToDynamicSelectColumns } from '../ts-dynamic-query-descriptor';
 import { mapper } from '../drivers/sqlite';
-import { capitalize, convertToCamelCaseName, generateRelationType, removeDuplicatedParameters2, renameInvalidNames, TsDescriptor, writeBuildOrderByBlock, writeBuildSqlFunction, writeDynamicQueryOperators, writeMapToResultFunction, writeNestedTypes, writeOrderByToObjectFunction, writeWhereConditionFunction, writeCollectFunction, writeGroupByFunction, createTypeNames, createCodeBlockWriter, writeDynamicQueryParamType, writeSelectFragements, writeSql } from './shared/codegen-util';
+import { capitalize, convertToCamelCaseName, generateRelationType, removeDuplicatedParameters2, renameInvalidNames, TsDescriptor, writeBuildOrderByBlock, writeBuildSqlFunction, writeDynamicQueryOperators, writeMapToResultFunction, writeNestedTypes, writeOrderByToObjectFunction, writeResultType, writeWhereConditionFunction, writeCollectFunction, writeGroupByFunction, createTypeNames, createCodeBlockWriter, writeDynamicQueryParamType, writeSelectFragements, writeSql } from './shared/codegen-util';
 
 type ExecFunctionParams = {
 	functionName: string;
@@ -353,8 +353,9 @@ function generateCodeFromTsDescriptor(client: SQLiteClient, queryName: string, t
 		writeDynamicQueryParamType(writer, queryName, paramsTypes.length > 0, orderByField);
 		writer.blankLine();
 		writeTypeBlock(writer, paramsTypes, paramsTypeName, false, tsDescriptor.dynamicQuery2 ? undefined : orderByField);
-		const resultTypes = tsDescriptor.dynamicQuery2 == null ? tsDescriptor.columns : mapToDynamicResultColumns(tsDescriptor.columns);
-		writeTypeBlock(writer, resultTypes, resultTypeName, false);
+		const resultTypes = tsDescriptor.columns.map((c) => ({ ...c, optional: true, notNull: true }));
+		writeResultType(writer, resultTypeName, resultTypes);
+		writer.blankLine();
 		const selectFields = mapToDynamicSelectColumns(tsDescriptor.columns);
 		writeTypeBlock(writer, selectFields, selectColumnsTypeName, false);
 		writeSelectFragements(writer, tsDescriptor.dynamicQuery2.select, tsDescriptor.columns);
@@ -464,12 +465,7 @@ function generateCodeFromTsDescriptor(client: SQLiteClient, queryName: string, t
 		}
 
 		writer.blankLine();
-		writer.write(`export type ${resultTypeName} =`).block(() => {
-			tsDescriptor.columns.forEach((field) => {
-				const optionalOp = field.notNull ? '' : '?';
-				writer.writeLine(`${field.name}${optionalOp}: ${field.tsType};`);
-			});
-		});
+		writeResultType(writer, resultTypeName, tsDescriptor.columns);
 		writer.blankLine();
 	}
 

--- a/src/ts-dynamic-query-descriptor.ts
+++ b/src/ts-dynamic-query-descriptor.ts
@@ -12,19 +12,6 @@ function mapToSelectColumn(r: TsFieldDescriptor): TsFieldDescriptor {
 	};
 }
 
-export function mapToDynamicResultColumns(columns: TsFieldDescriptor[]): TsFieldDescriptor[] {
-	return columns.map((column) => mapToResultColumn(column));
-}
-
-function mapToResultColumn(r: TsFieldDescriptor): TsFieldDescriptor {
-	return {
-		name: r.name,
-		tsType: r.tsType,
-		notNull: false,
-		optional: true
-	};
-}
-
 export function mapToDynamicParams(columns: TsFieldDescriptor[]): TsFieldDescriptor[] {
 	return columns.map((column) => mapToDynamicParam(column));
 }

--- a/tests/code-generator.test.ts
+++ b/tests/code-generator.test.ts
@@ -53,7 +53,7 @@ export type GetPersonParams = {
 
 export type GetPersonResult = {
     id: number;
-    name?: string;
+    name: string | null;
 }
 
 export async function getPerson(connection: Connection, params: GetPersonParams): Promise<GetPersonResult[]> {
@@ -116,7 +116,7 @@ export type GetPersonParams = {
 
 export type GetPersonResult = {
     id: number;
-    name?: string;
+    name: string | null;
 }
 
 export async function getPerson(connection: Connection, params: GetPersonParams): Promise<GetPersonResult[]> {
@@ -610,13 +610,13 @@ LEFT JOIN comments c on c.fk_post = p.id`;
 export type SelectUsersResult = {
     user_id: number;
     user_name: string;
-    post_id?: number;
-    post_title?: string;
-    post_body?: string;
-    role_id?: number;
-    role?: 'user' | 'admin' | 'guest';
-    comment_id?: number;
-    comment?: string;
+    post_id: number | null;
+    post_title: string | null;
+    post_body: string | null;
+    role_id: number | null;
+    role: 'user' | 'admin' | 'guest' | null;
+    comment_id: number | null;
+    comment: string | null;
 }
 
 export async function selectUsers(connection: Connection): Promise<SelectUsersResult[]> {
@@ -786,9 +786,9 @@ export type SelectUsersParams = {
 export type SelectUsersResult = {
     user_id: number;
     user_name: string;
-    post_id?: number;
-    post_title?: string;
-    post_body?: string;
+    post_id: number | null;
+    post_title: string | null;
+    post_body: string | null;
 }
 
 export async function selectUsers(connection: Connection, params: SelectUsersParams): Promise<SelectUsersResult[]> {
@@ -1030,7 +1030,7 @@ export type SelectClientsResult = {
     id_2: number;
     address: string;
     id_3: number;
-    address_2?: string;
+    address_2: string | null;
 }
 
 export async function selectClients(connection: Connection, params: SelectClientsParams): Promise<SelectClientsResult[]> {
@@ -1065,7 +1065,7 @@ function mapArrayToSelectClientsResult(data: any) {
 export type SelectClientsNestedC = {
     id: number;
     a1: SelectClientsNestedA1;
-    a2?: SelectClientsNestedA2;
+    a2: SelectClientsNestedA2 | null;
 }
 
 export type SelectClientsNestedA1 = {
@@ -1164,7 +1164,7 @@ export type SelectBooksResult = {
     author_ordinal: number;
     id_3: number;
     fullName: string;
-    shortName?: string;
+    shortName: string | null;
 }
 
 export async function selectBooks(connection: Connection): Promise<SelectBooksResult[]> {

--- a/tests/sqlite/expected-code/crud-select01-bun.ts.txt
+++ b/tests/sqlite/expected-code/crud-select01-bun.ts.txt
@@ -6,7 +6,7 @@ export type SelectFromMytable1Params = {
 
 export type SelectFromMytable1Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export function selectFromMytable1(db: Database, params: SelectFromMytable1Params): SelectFromMytable1Result | null {

--- a/tests/sqlite/expected-code/crud-select01-d1.ts.txt
+++ b/tests/sqlite/expected-code/crud-select01-d1.ts.txt
@@ -6,7 +6,7 @@ export type SelectFromMytable1Params = {
 
 export type SelectFromMytable1Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export async function selectFromMytable1(db: D1Database, params: SelectFromMytable1Params): Promise<SelectFromMytable1Result | null> {

--- a/tests/sqlite/expected-code/crud-select01-libsql.ts.txt
+++ b/tests/sqlite/expected-code/crud-select01-libsql.ts.txt
@@ -6,7 +6,7 @@ export type SelectFromMytable1Params = {
 
 export type SelectFromMytable1Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export async function selectFromMytable1(client: Client | Transaction, params: SelectFromMytable1Params): Promise<SelectFromMytable1Result | null> {

--- a/tests/sqlite/expected-code/crud-select01.ts.txt
+++ b/tests/sqlite/expected-code/crud-select01.ts.txt
@@ -6,7 +6,7 @@ export type SelectFromMytable1Params = {
 
 export type SelectFromMytable1Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export function selectFromMytable1(db: Database, params: SelectFromMytable1Params): SelectFromMytable1Result | null {

--- a/tests/sqlite/expected-code/delete02.ts.txt
+++ b/tests/sqlite/expected-code/delete02.ts.txt
@@ -6,7 +6,7 @@ export type Delete02Params = {
 
 export type Delete02Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export function delete02(db: Database, params: Delete02Params): Delete02Result {

--- a/tests/sqlite/expected-code/insert03-d1.ts.txt
+++ b/tests/sqlite/expected-code/insert03-d1.ts.txt
@@ -6,7 +6,7 @@ export type Insert03Params = {
 
 export type Insert03Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export async function insert03(db: D1Database, params: Insert03Params): Promise<Insert03Result> {

--- a/tests/sqlite/expected-code/insert03-libsql.ts.txt
+++ b/tests/sqlite/expected-code/insert03-libsql.ts.txt
@@ -6,7 +6,7 @@ export type Insert03Params = {
 
 export type Insert03Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export async function insert03(client: Client | Transaction, params: Insert03Params): Promise<Insert03Result> {

--- a/tests/sqlite/expected-code/insert03.ts.txt
+++ b/tests/sqlite/expected-code/insert03.ts.txt
@@ -6,7 +6,7 @@ export type Insert03Params = {
 
 export type Insert03Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export function insert03(db: Database, params: Insert03Params): Insert03Result {

--- a/tests/sqlite/expected-code/nested02-bun-clients-with-addresses.ts.txt
+++ b/tests/sqlite/expected-code/nested02-bun-clients-with-addresses.ts.txt
@@ -8,8 +8,8 @@ export type Nested02Result = {
 	id: number;
 	id_2: number;
 	address: string;
-	id_3?: number;
-	address_2?: string;
+	id_3: number | null;
+	address_2: string | null;
 }
 
 export function nested02(db: Database, params: Nested02Params): Nested02Result[] {

--- a/tests/sqlite/expected-code/nested02-clients-with-addresses.ts.txt
+++ b/tests/sqlite/expected-code/nested02-clients-with-addresses.ts.txt
@@ -8,8 +8,8 @@ export type Nested02Result = {
 	id: number;
 	id_2: number;
 	address: string;
-	id_3?: number;
-	address_2?: string;
+	id_3: number | null;
+	address_2: string | null;
 }
 
 export function nested02(db: Database, params: Nested02Params): Nested02Result[] {

--- a/tests/sqlite/expected-code/nested02-d1-clients-with-addresses.ts.txt
+++ b/tests/sqlite/expected-code/nested02-d1-clients-with-addresses.ts.txt
@@ -8,8 +8,8 @@ export type Nested02Result = {
 	id: number;
 	id_2: number;
 	address: string;
-	id_3?: number;
-	address_2?: string;
+	id_3: number | null;
+	address_2: string | null;
 }
 
 export async function nested02(db: D1Database, params: Nested02Params): Promise<Nested02Result[]> {

--- a/tests/sqlite/expected-code/select01-bun.ts.txt
+++ b/tests/sqlite/expected-code/select01-bun.ts.txt
@@ -6,7 +6,7 @@ export type Select01Params = {
 
 export type Select01Result = {
 	id: number;
-	name?: string;
+	name: string | null;
 }
 
 export function select01(db: Database, params: Select01Params): Select01Result | null {

--- a/tests/sqlite/expected-code/select01-d1.ts.txt
+++ b/tests/sqlite/expected-code/select01-d1.ts.txt
@@ -6,7 +6,7 @@ export type Select01Params = {
 
 export type Select01Result = {
 	id: number;
-	name?: string;
+	name: string | null;
 }
 
 export async function select01(db: D1Database, params: Select01Params): Promise<Select01Result | null> {

--- a/tests/sqlite/expected-code/select01-libsql.ts.txt
+++ b/tests/sqlite/expected-code/select01-libsql.ts.txt
@@ -6,7 +6,7 @@ export type Select01Params = {
 
 export type Select01Result = {
 	id: number;
-	name?: string;
+	name: string | null;
 }
 
 export async function select01(client: Client | Transaction, params: Select01Params): Promise<Select01Result | null> {

--- a/tests/sqlite/expected-code/select01.ts.txt
+++ b/tests/sqlite/expected-code/select01.ts.txt
@@ -6,7 +6,7 @@ export type Select01Params = {
 
 export type Select01Result = {
 	id: number;
-	name?: string;
+	name: string | null;
 }
 
 export function select01(db: Database, params: Select01Params): Select01Result | null {

--- a/tests/sqlite/expected-code/select04-bun.ts.txt
+++ b/tests/sqlite/expected-code/select04-bun.ts.txt
@@ -6,12 +6,12 @@ export type Select04Params = {
 }
 
 export type Select04Result = {
-	text_column?: string;
-	date_text?: Date;
-	datetime_text?: Date;
-	integer_column?: number;
-	date_integer?: Date;
-	datetime_integer?: Date;
+	text_column: string | null;
+	date_text: Date | null;
+	datetime_text: Date | null;
+	integer_column: number | null;
+	date_integer: Date | null;
+	datetime_integer: Date | null;
 }
 
 export function select04(db: Database, params: Select04Params): Select04Result[] {

--- a/tests/sqlite/expected-code/select04-d1.ts.txt
+++ b/tests/sqlite/expected-code/select04-d1.ts.txt
@@ -6,12 +6,12 @@ export type Select04Params = {
 }
 
 export type Select04Result = {
-	text_column?: string;
-	date_text?: Date;
-	datetime_text?: Date;
-	integer_column?: number;
-	date_integer?: Date;
-	datetime_integer?: Date;
+	text_column: string | null;
+	date_text: Date | null;
+	datetime_text: Date | null;
+	integer_column: number | null;
+	date_integer: Date | null;
+	datetime_integer: Date | null;
 }
 
 export async function select04(db: D1Database, params: Select04Params): Promise<Select04Result[]> {

--- a/tests/sqlite/expected-code/select04.ts.txt
+++ b/tests/sqlite/expected-code/select04.ts.txt
@@ -6,12 +6,12 @@ export type Select04Params = {
 }
 
 export type Select04Result = {
-	text_column?: string;
-	date_text?: Date;
-	datetime_text?: Date;
-	integer_column?: number;
-	date_integer?: Date;
-	datetime_integer?: Date;
+	text_column: string | null;
+	date_text: Date | null;
+	datetime_text: Date | null;
+	integer_column: number | null;
+	date_integer: Date | null;
+	datetime_integer: Date | null;
 }
 
 export function select04(db: Database, params: Select04Params): Select04Result[] {

--- a/tests/sqlite/expected-code/select07-fts.ts.txt
+++ b/tests/sqlite/expected-code/select07-fts.ts.txt
@@ -5,9 +5,9 @@ export type Select07Params = {
 }
 
 export type Select07Result = {
-	id?: any;
-	name?: any;
-	descr?: any;
+	id: any | null;
+	name: any | null;
+	descr: any | null;
 }
 
 export function select07(db: Database, params: Select07Params): Select07Result[] {

--- a/tests/sqlite/expected-code/select08-boolean.ts.txt
+++ b/tests/sqlite/expected-code/select08-boolean.ts.txt
@@ -8,7 +8,7 @@ export type Select08Params = {
 export type Select08Result = {
 	id: number;
 	param1: boolean;
-	param2?: boolean;
+	param2: boolean | null;
 }
 
 export function select08(db: Database, params: Select08Params): Select08Result[] {

--- a/tests/sqlite/expected-code/update03.ts.txt
+++ b/tests/sqlite/expected-code/update03.ts.txt
@@ -10,7 +10,7 @@ export type Update03Params = {
 
 export type Update03Result = {
 	id: number;
-	value?: number;
+	value: number | null;
 }
 
 export function update03(db: Database, data: Update03Data, params: Update03Params): Update03Result {


### PR DESCRIPTION
Mirror PR #87 for sqlite and mysql2 codegen. Nullable result columns now emit `field: T | null` rather than `field?: T`. Matches runtime reality (null is returned, not undefined) and unblocks `value || fallback` without TS errors.

- Shared writeResultType helper in codegen-util.ts.
- Dynamic-query result cols remap to {optional: true, notNull: true} at call site, mirroring PG template (name?: T, no | null).
- Drop dead mapToDynamicResultColumns.

Closes #117