### PR TITLE
fix(postgres): EXTRACT() returns numeric (PG14+)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
-  mysql-dev: 
+  mysql-dev:
     # image: "mysql:5.7.41"
     image: "mysql:8.0.33"
     container_name: "mysql-dev"
@@ -10,8 +10,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: "password"
       MYSQL_DATABASE: "mydb"
-  postgres-dev: 
-    image: "postgres:12.21"
+  postgres-dev:
+    image: "postgres:17"
     container_name: "postgres-dev"
     ports:
       - "5432:5432"

--- a/src/postgres-query-analyzer/traverse.ts
+++ b/src/postgres-query-analyzer/traverse.ts
@@ -1558,7 +1558,7 @@ function traversefunc_expr_common_subexpr(func_expr_common_subexpr: Func_expr_co
 			is_nullable: result.is_nullable,
 			table: '',
 			schema: '',
-			type: 'float8'
+			type: 'numeric'
 		}
 	}
 	func_expr_common_subexpr.a_expr_list().forEach(a_expr => {

--- a/tests/postgres/expected-code/dynamic-query08-date.ts.txt
+++ b/tests/postgres/expected-code/dynamic-query08-date.ts.txt
@@ -8,8 +8,8 @@ export type DynamicQuery08DynamicParams = {
 }
 
 export type DynamicQuery08Params = {
-	param1: number;
-	param2: number;
+	param1: string;
+	param2: string;
 }
 
 export type DynamicQuery08Result = {

--- a/tests/postgres/parse-json-functions.test.ts
+++ b/tests/postgres/parse-json-functions.test.ts
@@ -1376,7 +1376,7 @@ describe('postgres-json-functions', () => {
 						properties: [
 							{
 								key: 'extract_year',
-								type: { name: 'json_field', type: 'float8', notNull: true }
+								type: { name: 'json_field', type: 'numeric', notNull: true }
 							}
 						],
 					},

--- a/tests/postgres/parse-select-functions.test.ts
+++ b/tests/postgres/parse-select-functions.test.ts
@@ -356,25 +356,25 @@ describe('postgres-parse-select-functions', () => {
 			columns: [
 				{
 					name: 'month1',
-					type: 'float8',
+					type: 'numeric',
 					notNull: false,
 					table: ''
 				},
 				{
 					name: 'month2',
-					type: 'float8',
+					type: 'numeric',
 					notNull: true,
 					table: ''
 				},
 				{
 					name: 'month3',
-					type: 'float8',
+					type: 'numeric',
 					notNull: false,
 					table: ''
 				},
 				{
 					name: 'month4',
-					type: 'float8',
+					type: 'numeric',
 					notNull: true,
 					table: ''
 				}


### PR DESCRIPTION
## Changes

Fixes the type mapping for `EXTRACT()` to match modern PostgreSQL semantics:

- Parser hardcode `float8` → `numeric` in `src/postgres-query-analyzer/traverse.ts:1561`
- Test fixtures updated to expect `numeric` (mapped to TS `string`)
- `docker-compose.yml`: postgres bumped from `12.21` to `17`

## Why

PostgreSQL 14 changed `EXTRACT()`'s return type from `double precision` (`float8`) to `numeric` (release notes [E.7.3.1.1](https://www.postgresql.org/docs/14/release-14.html)). PG12 and PG13 are EOL'd (2024-11 and 2025-11 respectively), so the test suite now targets PG17 and the parser reflects modern semantics.