### PR TITLE
fix(sqlite): single row RETURNING codegen

### DIFF
--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -868,13 +868,24 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
 					}
 				}
-				if (queryType === 'Insert') {
-					if (returning) {
-						writer.indent().write('.then(res => res.rows)').newLine();
-						writer.indent().write(`.then(rows => mapArrayTo${resultTypeName}(rows[0]));`);
+				if (queryType === 'Insert' && returning) {
+					writer.indent().write('.then(res => res.rows)').newLine();
+					// TODO(T17): `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
+					if (multipleRowsResult) {
+						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
+					} else {
+						writer.indent().write(`.then(rows => { if (rows.length === 0) { throw new Error('${INSERT_RETURNING_NO_ROWS_ERROR}'); } return mapArrayTo${resultTypeName}(rows[0]); });`);
 					}
 				}
-				if (queryType === 'Update' || queryType === 'Delete' || (queryType === 'Insert' && !returning)) {
+				if ((queryType === 'Update' || queryType === 'Delete') && returning) {
+					writer.indent().write('.then(res => res.rows)').newLine();
+					if (multipleRowsResult) {
+						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
+					} else {
+						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
+					}
+				}
+				if ((queryType === 'Update' || queryType === 'Delete' || queryType === 'Insert') && !returning) {
 					writer.indent().write(`.then(res => mapArrayTo${resultTypeName}(res));`);
 				}
 			});

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -949,14 +949,26 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
 					}
 				}
-				if (queryType === 'Insert' || queryType === 'Update' || queryType === 'Delete') {
-					if (returning) {
-						writer.indent().write('.raw({ columnNames: false })').newLine();
-						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row))[0]);`);
+				if (queryType === 'Insert' && returning) {
+					writer.indent().write('.raw({ columnNames: false })').newLine();
+					// TODO(T17): `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
+					if (multipleRowsResult) {
+						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
 					} else {
-						writer.indent().write('.run()').newLine();
-						writer.indent().write(`.then(res => res.meta);`);
+						writer.indent().write(`.then(rows => { if (rows.length === 0) { throw new Error('${INSERT_RETURNING_NO_ROWS_ERROR}'); } return mapArrayTo${resultTypeName}(rows[0]); });`);
 					}
+				}
+				if ((queryType === 'Update' || queryType === 'Delete') && returning) {
+					writer.indent().write('.raw({ columnNames: false })').newLine();
+					if (multipleRowsResult) {
+						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
+					} else {
+						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
+					}
+				}
+				if ((queryType === 'Insert' || queryType === 'Update' || queryType === 'Delete') && !returning) {
+					writer.indent().write('.run()').newLine();
+					writer.indent().write(`.then(res => res.meta);`);
 				}
 			});
 			if (queryType === 'Select' || returning) {

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -899,26 +899,32 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 			return;
 		case 'bun:sqlite':
 			const bunArgs = 'db: Database' + restParameters;
-			if (queryType === 'Select') {
+			if (queryType === 'Select' || returning) {
 				writer.write(`export function ${functionName}(${bunArgs}): ${returnType}`).block(() => {
 					writeSql(writer, sql);
 					if (multipleRowsResult) {
 						writer.write('return db.prepare(sql)').newLine();
 						writer.indent().write(`.values(${queryParametersWithoutBrackes})`).newLine();
-						writer.indent().write(`.map(data => mapArrayTo${resultTypeName}(data))${multipleRowsResult ? '' : '[0]'};`);
+						writer.indent().write(`.map(data => mapArrayTo${resultTypeName}(data));`);
 					}
 					else {
 						writer.write('const res = db.prepare(sql)').newLine();
 						writer.indent().write(`.values(${queryParametersWithoutBrackes});`).newLine();
 						writer.blankLine();
-						writer.write(`return res.length > 0 ? mapArrayTo${resultTypeName}(res[0]) : null;`);
+						if (returning && queryType === 'Insert') {
+							writer.write(`if (res.length === 0) { throw new Error('${INSERT_RETURNING_NO_ROWS_ERROR}'); }`).newLine();
+							writer.write(`return mapArrayTo${resultTypeName}(res[0]);`);
+						}
+						else {
+							writer.write(`return res.length > 0 ? mapArrayTo${resultTypeName}(res[0]) : null;`);
+						}
 					}
 
 				});
 				writer.blankLine();
 				writeMapFunction(writer, mapFunctionParams);
 			}
-			if (queryType === 'Update' || queryType === 'Delete' || (queryType === 'Insert' && !returning)) {
+			if ((queryType === 'Update' || queryType === 'Delete' || queryType === 'Insert') && !returning) {
 				writer.write(`export function ${functionName}(${bunArgs}): ${resultTypeName}`).block(() => {
 					writeSql(writer, sql);
 					writer.write('return db.prepare(sql)').newLine();

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -18,6 +18,8 @@ import type {
 	TypeSqlError
 } from '../types';
 import type { SQLiteType } from '../sqlite-query-analyzer/types';
+
+const INSERT_RETURNING_NO_ROWS_ERROR = 'INSERT ... RETURNING returned no rows';
 import type { Field2 } from '../sqlite-query-analyzer/sqlite-describe-nested-query';
 import { type RelationType2, type TsField2, mapToTsRelation2 } from '../ts-nested-descriptor';
 import { preprocessSql } from '../describe-query';
@@ -862,15 +864,11 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 
 				if (queryType === 'Select') {
 					writer.indent().write('.then(res => res.rows)').newLine();
-					if (multipleRowsResult) {
-						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
-					} else {
-						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
-					}
+					writeRowsResultMapping(writer, resultTypeName, multipleRowsResult);
 				}
 				if (queryType === 'Insert' && returning) {
 					writer.indent().write('.then(res => res.rows)').newLine();
-					// TODO(T17): `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
+					// TODO: `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
 					if (multipleRowsResult) {
 						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
 					} else {
@@ -879,11 +877,7 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 				}
 				if ((queryType === 'Update' || queryType === 'Delete') && returning) {
 					writer.indent().write('.then(res => res.rows)').newLine();
-					if (multipleRowsResult) {
-						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
-					} else {
-						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
-					}
+					writeRowsResultMapping(writer, resultTypeName, multipleRowsResult);
 				}
 				if ((queryType === 'Update' || queryType === 'Delete' || queryType === 'Insert') && !returning) {
 					writer.indent().write(`.then(res => mapArrayTo${resultTypeName}(res));`);
@@ -943,15 +937,11 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 
 				if (queryType === 'Select') {
 					writer.indent().write('.raw({ columnNames: false })').newLine();
-					if (multipleRowsResult) {
-						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
-					} else {
-						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
-					}
+					writeRowsResultMapping(writer, resultTypeName, multipleRowsResult);
 				}
 				if (queryType === 'Insert' && returning) {
 					writer.indent().write('.raw({ columnNames: false })').newLine();
-					// TODO(T17): `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
+					// TODO: `multipleRowsResult === true` branch unreachable until analyzer fix (B5/B6).
 					if (multipleRowsResult) {
 						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
 					} else {
@@ -960,11 +950,7 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 				}
 				if ((queryType === 'Update' || queryType === 'Delete') && returning) {
 					writer.indent().write('.raw({ columnNames: false })').newLine();
-					if (multipleRowsResult) {
-						writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
-					} else {
-						writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
-					}
+					writeRowsResultMapping(writer, resultTypeName, multipleRowsResult);
 				}
 				if ((queryType === 'Insert' || queryType === 'Update' || queryType === 'Delete') && !returning) {
 					writer.indent().write('.run()').newLine();
@@ -978,6 +964,18 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 			return;
 		default:
 			return client satisfies never;
+	}
+}
+
+// TODO: the `multipleRowsResult === true` branch below is currently UNREACHABLE for U/D/INSERT
+// RETURNING because src/sqlite-query-analyzer/parser.ts hardcodes the flag to false for all DML.
+// Branch is correct-by-construction but dead until multirow analyzer fix lands.
+// Do not delete — removing it now would force a re-derivation when the fix lands.
+function writeRowsResultMapping(writer: CodeBlockWriter, resultTypeName: string, multipleRowsResult: boolean): void {
+	if (multipleRowsResult) {
+		writer.indent().write(`.then(rows => rows.map(row => mapArrayTo${resultTypeName}(row)));`);
+	} else {
+		writer.indent().write(`.then(rows => rows.length > 0 ? mapArrayTo${resultTypeName}(rows[0]) : null);`);
 	}
 }
 

--- a/src/codegen/sqlite.ts
+++ b/src/codegen/sqlite.ts
@@ -336,7 +336,9 @@ function generateCodeFromTsDescriptor(client: SQLiteClient, queryName: string, t
 		functionArguments += `, ${orderByField ? 'params' : 'params?'}: ${dynamicParamsTypeName}`;
 	}
 
-	const orNull = queryType === 'Select' ? ' | null' : '';
+	const orNull = queryType === 'Select'
+		|| ((queryType === 'Update' || queryType === 'Delete') && tsDescriptor.returning === true && !tsDescriptor.multipleRowsResult)
+		? ' | null' : '';
 	const returnType = tsDescriptor.multipleRowsResult ? `${resultTypeName}[]` : `${resultTypeName}${orNull}`;
 
 	const allParameters = (tsDescriptor.data?.map((param) => toDriver('data', param)) || []).concat(
@@ -829,11 +831,12 @@ function writeExecFunction(writer: CodeBlockWriter, client: SQLiteClient, params
 						writer.indent().write('.raw(true)').newLine();
 						writer.indent().write(`.get(${queryParams});`).newLine();
 						writer.blankLine();
-						if (!returning) {
-							writer.write(`return res ? mapArrayTo${resultTypeName}(res) : null;`);
+						if (returning && queryType === 'Insert') {
+							writer.write(`if (!res) { throw new Error('${INSERT_RETURNING_NO_ROWS_ERROR}'); }`).newLine();
+							writer.write(`return mapArrayTo${resultTypeName}(res);`);
 						}
 						else {
-							writer.write(`return mapArrayTo${resultTypeName}(res);`);
+							writer.write(`return res ? mapArrayTo${resultTypeName}(res) : null;`);
 						}
 					}
 				});

--- a/tests/sqlite/expected-code/delete02-bun.ts.txt
+++ b/tests/sqlite/expected-code/delete02-bun.ts.txt
@@ -1,0 +1,28 @@
+import type { Database } from 'bun:sqlite';
+
+export type Delete02Params = {
+	param1: number;
+}
+
+export type Delete02Result = {
+	id: number;
+	value: number | null;
+}
+
+export function delete02(db: Database, params: Delete02Params): Delete02Result | null {
+	const sql = `
+	DELETE FROM mytable1 WHERE id=? RETURNING *
+	`
+	const res = db.prepare(sql)
+		.values(params.param1);
+
+	return res.length > 0 ? mapArrayToDelete02Result(res[0]) : null;
+}
+
+function mapArrayToDelete02Result(data: any) {
+	const result: Delete02Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/delete02-d1.ts.txt
+++ b/tests/sqlite/expected-code/delete02-d1.ts.txt
@@ -1,0 +1,28 @@
+import type { D1Database } from '@cloudflare/workers-types';
+
+export type Delete02Params = {
+	param1: number;
+}
+
+export type Delete02Result = {
+	id: number;
+	value: number | null;
+}
+
+export async function delete02(db: D1Database, params: Delete02Params): Promise<Delete02Result | null> {
+	const sql = `
+	DELETE FROM mytable1 WHERE id=? RETURNING *
+	`
+	return db.prepare(sql)
+		.bind(params.param1)
+		.raw({ columnNames: false })
+		.then(rows => rows.length > 0 ? mapArrayToDelete02Result(rows[0]) : null);
+}
+
+function mapArrayToDelete02Result(data: any) {
+	const result: Delete02Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/delete02-libsql.ts.txt
+++ b/tests/sqlite/expected-code/delete02-libsql.ts.txt
@@ -1,0 +1,27 @@
+import type { Client, Transaction } from '@libsql/client';
+
+export type Delete02Params = {
+	param1: number;
+}
+
+export type Delete02Result = {
+	id: number;
+	value: number | null;
+}
+
+export async function delete02(client: Client | Transaction, params: Delete02Params): Promise<Delete02Result | null> {
+	const sql = `
+	DELETE FROM mytable1 WHERE id=? RETURNING *
+	`
+	return client.execute({ sql, args: [params.param1] })
+		.then(res => res.rows)
+		.then(rows => rows.length > 0 ? mapArrayToDelete02Result(rows[0]) : null);
+}
+
+function mapArrayToDelete02Result(data: any) {
+	const result: Delete02Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/delete02.ts.txt
+++ b/tests/sqlite/expected-code/delete02.ts.txt
@@ -9,7 +9,7 @@ export type Delete02Result = {
 	value: number | null;
 }
 
-export function delete02(db: Database, params: Delete02Params): Delete02Result {
+export function delete02(db: Database, params: Delete02Params): Delete02Result | null {
 	const sql = `
 	DELETE FROM mytable1 WHERE id=? RETURNING *
 	`
@@ -17,7 +17,7 @@ export function delete02(db: Database, params: Delete02Params): Delete02Result {
 		.raw(true)
 		.get([params.param1]);
 
-	return mapArrayToDelete02Result(res);
+	return res ? mapArrayToDelete02Result(res) : null;
 }
 
 function mapArrayToDelete02Result(data: any) {

--- a/tests/sqlite/expected-code/insert03-bun.ts.txt
+++ b/tests/sqlite/expected-code/insert03-bun.ts.txt
@@ -1,0 +1,29 @@
+import type { Database } from 'bun:sqlite';
+
+export type Insert03Params = {
+	value: number | null;
+}
+
+export type Insert03Result = {
+	id: number;
+	value: number | null;
+}
+
+export function insert03(db: Database, params: Insert03Params): Insert03Result {
+	const sql = `
+	INSERT INTO mytable1(value) VALUES(?) RETURNING *
+	`
+	const res = db.prepare(sql)
+		.values(params.value);
+
+	if (res.length === 0) { throw new Error('INSERT ... RETURNING returned no rows'); }
+	return mapArrayToInsert03Result(res[0]);
+}
+
+function mapArrayToInsert03Result(data: any) {
+	const result: Insert03Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/insert03-d1.ts.txt
+++ b/tests/sqlite/expected-code/insert03-d1.ts.txt
@@ -16,7 +16,7 @@ export async function insert03(db: D1Database, params: Insert03Params): Promise<
 	return db.prepare(sql)
 		.bind(params.value)
 		.raw({ columnNames: false })
-		.then(rows => rows.map(row => mapArrayToInsert03Result(row))[0]);
+		.then(rows => { if (rows.length === 0) { throw new Error('INSERT ... RETURNING returned no rows'); } return mapArrayToInsert03Result(rows[0]); });
 }
 
 function mapArrayToInsert03Result(data: any) {

--- a/tests/sqlite/expected-code/insert03-libsql.ts.txt
+++ b/tests/sqlite/expected-code/insert03-libsql.ts.txt
@@ -15,7 +15,7 @@ export async function insert03(client: Client | Transaction, params: Insert03Par
 	`
 	return client.execute({ sql, args: [params.value] })
 		.then(res => res.rows)
-		.then(rows => mapArrayToInsert03Result(rows[0]));
+		.then(rows => { if (rows.length === 0) { throw new Error('INSERT ... RETURNING returned no rows'); } return mapArrayToInsert03Result(rows[0]); });
 }
 
 function mapArrayToInsert03Result(data: any) {

--- a/tests/sqlite/expected-code/insert03.ts.txt
+++ b/tests/sqlite/expected-code/insert03.ts.txt
@@ -17,6 +17,7 @@ export function insert03(db: Database, params: Insert03Params): Insert03Result {
 		.raw(true)
 		.get([params.value]);
 
+	if (!res) { throw new Error('INSERT ... RETURNING returned no rows'); }
 	return mapArrayToInsert03Result(res);
 }
 

--- a/tests/sqlite/expected-code/update03-bun.ts.txt
+++ b/tests/sqlite/expected-code/update03-bun.ts.txt
@@ -1,0 +1,32 @@
+import type { Database } from 'bun:sqlite';
+
+export type Update03Data = {
+	param1: number | null;
+}
+
+export type Update03Params = {
+	param1: number;
+}
+
+export type Update03Result = {
+	id: number;
+	value: number | null;
+}
+
+export function update03(db: Database, data: Update03Data, params: Update03Params): Update03Result | null {
+	const sql = `
+	UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *
+	`
+	const res = db.prepare(sql)
+		.values(data.param1, params.param1);
+
+	return res.length > 0 ? mapArrayToUpdate03Result(res[0]) : null;
+}
+
+function mapArrayToUpdate03Result(data: any) {
+	const result: Update03Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/update03-d1.ts.txt
+++ b/tests/sqlite/expected-code/update03-d1.ts.txt
@@ -1,0 +1,32 @@
+import type { D1Database } from '@cloudflare/workers-types';
+
+export type Update03Data = {
+	param1: number | null;
+}
+
+export type Update03Params = {
+	param1: number;
+}
+
+export type Update03Result = {
+	id: number;
+	value: number | null;
+}
+
+export async function update03(db: D1Database, data: Update03Data, params: Update03Params): Promise<Update03Result | null> {
+	const sql = `
+	UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *
+	`
+	return db.prepare(sql)
+		.bind(data.param1, params.param1)
+		.raw({ columnNames: false })
+		.then(rows => rows.length > 0 ? mapArrayToUpdate03Result(rows[0]) : null);
+}
+
+function mapArrayToUpdate03Result(data: any) {
+	const result: Update03Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/update03-libsql.ts.txt
+++ b/tests/sqlite/expected-code/update03-libsql.ts.txt
@@ -1,0 +1,31 @@
+import type { Client, Transaction } from '@libsql/client';
+
+export type Update03Data = {
+	param1: number | null;
+}
+
+export type Update03Params = {
+	param1: number;
+}
+
+export type Update03Result = {
+	id: number;
+	value: number | null;
+}
+
+export async function update03(client: Client | Transaction, data: Update03Data, params: Update03Params): Promise<Update03Result | null> {
+	const sql = `
+	UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *
+	`
+	return client.execute({ sql, args: [data.param1, params.param1] })
+		.then(res => res.rows)
+		.then(rows => rows.length > 0 ? mapArrayToUpdate03Result(rows[0]) : null);
+}
+
+function mapArrayToUpdate03Result(data: any) {
+	const result: Update03Result = {
+		id: data[0],
+		value: data[1]
+	}
+	return result;
+}

--- a/tests/sqlite/expected-code/update03.ts.txt
+++ b/tests/sqlite/expected-code/update03.ts.txt
@@ -13,7 +13,7 @@ export type Update03Result = {
 	value: number | null;
 }
 
-export function update03(db: Database, data: Update03Data, params: Update03Params): Update03Result {
+export function update03(db: Database, data: Update03Data, params: Update03Params): Update03Result | null {
 	const sql = `
 	UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *
 	`
@@ -21,7 +21,7 @@ export function update03(db: Database, data: Update03Data, params: Update03Param
 		.raw(true)
 		.get([data.param1, params.param1]);
 
-	return mapArrayToUpdate03Result(res);
+	return res ? mapArrayToUpdate03Result(res) : null;
 }
 
 function mapArrayToUpdate03Result(data: any) {

--- a/tests/sqlite/sqlite-code-generator.test.ts
+++ b/tests/sqlite/sqlite-code-generator.test.ts
@@ -444,6 +444,19 @@ AND datetime(integer_column, 'auto') = :date_time`;
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('update03-libsql - returning *', () => {
+		const sql = 'UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *';
+
+		const actual = generateTsCode(sql, 'update03', sqliteDbSchema, 'libsql', false);
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/update03-libsql.ts.txt');
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('delete01 - DELETE FROM mytable1 WHERE id=?', () => {
 		const sql = 'DELETE FROM mytable1 WHERE id=?';
 
@@ -497,6 +510,18 @@ AND datetime(integer_column, 'auto') = :date_time`;
 
 		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'better-sqlite3');
 		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02.ts.txt');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
+	it('delete02-libsql - returning *', () => {
+		const sql = 'DELETE FROM mytable1 WHERE id=? RETURNING *';
+
+		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'libsql', false);
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02-libsql.ts.txt');
 
 		if (isLeft(actual)) {
 			assert.fail(`Shouldn't return an error: ${actual.left.description}`);

--- a/tests/sqlite/sqlite-code-generator.test.ts
+++ b/tests/sqlite/sqlite-code-generator.test.ts
@@ -319,6 +319,18 @@ AND datetime(integer_column, 'auto') = :date_time`;
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('insert03-bun - INSERT INTO mytable1(value) VALUES(:value) RETURNING *', () => {
+		const sql = 'INSERT INTO mytable1(value) VALUES(:value) RETURNING *';
+
+		const actual = generateTsCode(sql, 'insert03', sqliteDbSchema, 'bun:sqlite', false);
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/insert03-bun.ts.txt');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('insert03-d1 - INSERT INTO mytable1(value) VALUES(:value) RETURNING *', async () => {
 		const sql = 'INSERT INTO mytable1(value) VALUES(:value) RETURNING *';
 
@@ -457,6 +469,19 @@ AND datetime(integer_column, 'auto') = :date_time`;
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('update03-bun - returning *', () => {
+		const sql = 'UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *';
+
+		const actual = generateTsCode(sql, 'update03', sqliteDbSchema, 'bun:sqlite');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/update03-bun.ts.txt');
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('delete01 - DELETE FROM mytable1 WHERE id=?', () => {
 		const sql = 'DELETE FROM mytable1 WHERE id=?';
 
@@ -522,6 +547,18 @@ AND datetime(integer_column, 'auto') = :date_time`;
 
 		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'libsql', false);
 		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02-libsql.ts.txt');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
+	it('delete02-bun - returning *', () => {
+		const sql = 'DELETE FROM mytable1 WHERE id=? RETURNING *';
+
+		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'bun:sqlite');
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02-bun.ts.txt');
 
 		if (isLeft(actual)) {
 			assert.fail(`Shouldn't return an error: ${actual.left.description}`);

--- a/tests/sqlite/sqlite-code-generator.test.ts
+++ b/tests/sqlite/sqlite-code-generator.test.ts
@@ -482,6 +482,19 @@ AND datetime(integer_column, 'auto') = :date_time`;
 		assert.deepStrictEqual(actual.right, expected);
 	});
 
+	it('update03-d1 - returning *', () => {
+		const sql = 'UPDATE mytable1 SET value = ? WHERE id = ? RETURNING *';
+
+		const actual = generateTsCode(sql, 'update03', sqliteDbSchema, 'd1');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/update03-d1.ts.txt');
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
 	it('delete01 - DELETE FROM mytable1 WHERE id=?', () => {
 		const sql = 'DELETE FROM mytable1 WHERE id=?';
 
@@ -559,6 +572,18 @@ AND datetime(integer_column, 'auto') = :date_time`;
 
 		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'bun:sqlite');
 		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02-bun.ts.txt');
+
+		if (isLeft(actual)) {
+			assert.fail(`Shouldn't return an error: ${actual.left.description}`);
+		}
+		assert.deepStrictEqual(actual.right, expected);
+	});
+
+	it('delete02-d1 - returning *', () => {
+		const sql = 'DELETE FROM mytable1 WHERE id=? RETURNING *';
+
+		const actual = generateTsCode(sql, 'delete02', sqliteDbSchema, 'd1');
+		const expected = readNormalizedEOL('tests/sqlite/expected-code/delete02-d1.ts.txt');
 
 		if (isLeft(actual)) {
 			assert.fail(`Shouldn't return an error: ${actual.left.description}`);


### PR DESCRIPTION
Closes #122.

## Summary

Fixes broken or missing `RETURNING` codegen for `INSERT`/`UPDATE`/`DELETE` statements across all 4 SQLite drivers (better-sqlite3, libsql, bun:sqlite, d1). Each driver had a distinct defect; pg and mysql2 codegen are unchanged.

## What was broken

- **better-sqlite3**: single-row U/D RETURNING emitted `mapArrayTo<T>(res)` with no null guard — `.get()` returns `undefined` on 0 rows, producing crashes or garbage.
- **libsql** (#122): U/D/INSERT RETURNING indexed the libsql `ResultSet` as if it were an array, with no 0-row handling and no multi-row map.
- **bun:sqlite**: had no RETURNING branch at all — `UPDATE/DELETE … RETURNING` fell into the `.run()` path and silently dropped output while the type signature lied.
- **d1**: returning branch emitted `rows.map(...)[0]`, returning `undefined` on 0 rows with no `INSERT` guard and no multi-row path.

## What changed

Per-driver, `RETURNING` codegen now uses the correct accessor for that driver's row representation and respects result cardinality:

- Single-row `UPDATE/DELETE … RETURNING` returns `T | null` with an explicit empty-result guard.
- Multi-row `UPDATE/DELETE … RETURNING` returns `T[]` via `rows.map(...)`.
- `INSERT … RETURNING` (single-row): returns `T`, throws `Error('INSERT ... RETURNING returned no rows')` if the row vanishes (e.g. concurrent constraint violation handled outside the wrapper).
- `INSERT … RETURNING` (multi-row): returns `T[]` via `rows.map(...)`.

Also extracts a shared `writeRowsResultMapping` helper for the U/D RETURNING shape and a module-scope `INSERT_RETURNING_NO_ROWS_ERROR` constant to remove duplicated error literals across the 4 driver branches.

The `orNull` return-type rule is widened so single-row U/D RETURNING gets `T | null` regardless of driver.

## Known limitation (followup)

The SQLite analyzer in `src/sqlite-query-analyzer/parser.ts` currently hardcodes `multipleRowsResult: false` for all DML schema results. As a consequence, the new multi-row `RETURNING` codegen branches are correct-by-construction but currently **unreachable through the public `generateTsCode` API**. They are kept in place — and tagged with `TODO` comments — so they will Just Work the moment the analyzer is fixed in a followup.

Until the followup lands, queries like `INSERT … VALUES (?,?),(?,?) RETURNING *` or `UPDATE … RETURNING *` (without `LIMIT 1`) emit single-row codegen, which type-lies for the multi-row case.

## Test plan

- [x] `npm test` (sqlite codegen suite) — 102 passing
- [x] Single-row `UPDATE`/`DELETE` RETURNING fixtures added for libsql, bun:sqlite, d1; existing better-sqlite3 fixtures updated to `T | null` shape
- [x] `INSERT … RETURNING` throw-guard fixtures across all 4 drivers
- [x] pg + mysql2 fixtures byte-identical (regression gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Opus 4.7